### PR TITLE
Blocked webs/apps event Posthog

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,5 @@ Ebb uses your window, mouse and keyboard activity to track your workflow habits.
 
 The monitoring service is a Rust application that runs on your computer and is responsible for recording your activities. It is designed to be run as a background service and will not interfere with your workflow. Makes use of the os-monitor crate to monitor your activities and then record them to the database on your device.
 
-# [Monitor](https://github.com/CodeClimbersIO/os-monitor)
 
 The monitor is a Rust application that runs on your computer and is responsible for monitoring your activities. It is specifically responsible for monitoring (but not recording) your window, mouse and keyboard activity.

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ Ebb uses your window, mouse and keyboard activity to track your workflow habits.
 
 The monitoring service is a Rust application that runs on your computer and is responsible for recording your activities. It is designed to be run as a background service and will not interfere with your workflow. Makes use of the os-monitor crate to monitor your activities and then record them to the database on your device.
 
-
+# [Monitor](https://github.com/CodeClimbersIO/os-monitor)
 The monitor is a Rust application that runs on your computer and is responsible for monitoring your activities. It is specifically responsible for monitoring (but not recording) your window, mouse and keyboard activity.

--- a/src/api/ebbApi/blockingPreferenceApi.ts
+++ b/src/api/ebbApi/blockingPreferenceApi.ts
@@ -139,58 +139,10 @@ const getDefaultSearchOptions = async (): Promise<SearchOption[]> => {
   return defaultSearchOptions
 }
 
-interface BlockingAnalyticsData {
-  blocked_apps_count: number
-  blocked_websites_count: number
-  total_blocked_count: number
-  blocked_app_names: string[]
-  blocked_website_names: string[]
-}
-
-const getWorkflowBlockedAppsAnalytics = async (workflowId: string): Promise<BlockingAnalyticsData> => {
-  const selectedApps = await getWorkflowBlockingPreferencesAsSearchOptions(workflowId)
-
-  const directAppSelections: App[] = selectedApps
-    .filter((option): option is Extract<SearchOption, { type: 'app' }> => option.type === 'app' && !!option.app)
-    .map(option => option.app)
-
-  const categorySelections: Tag[] = selectedApps
-    .filter((option): option is Extract<SearchOption, { type: 'category' }> => option.type === 'category' && !!option.tag)
-    .map(option => option.tag)
-
-  const categoryTagIds = categorySelections.map(tag => tag.id).filter(id => !!id) as string[]
-
-  const appsFromCategories = categoryTagIds.length > 0
-    ? await AppRepo.getAppsByCategoryTags(categoryTagIds)
-    : []
-
-  const allAppsToConsider = [...directAppSelections, ...appsFromCategories]
-
-  const uniqueAppsMap = new Map<string, App>()
-  allAppsToConsider.forEach(app => {
-    if (app && app.id) {
-      uniqueAppsMap.set(app.id, app)
-    }
-  })
-  const uniqueApps = Array.from(uniqueAppsMap.values())
-
-  const apps = uniqueApps.filter(app => !app.is_browser)
-  const websites = uniqueApps.filter(app => app.is_browser)
-
-  return {
-    blocked_apps_count: apps.length,
-    blocked_websites_count: websites.length,
-    total_blocked_count: uniqueApps.length,
-    blocked_app_names: apps.map(app => app.name),
-    blocked_website_names: websites.map(app => app.name),
-  }
-}
-
 export const BlockingPreferenceApi = {
   getWorkflowBlockingPreferencesAsSearchOptions,
   saveWorkflowBlockingPreferences,
   getWorkflowBlockedApps,
   getDefaultSearchOptions,
-  getWorkflowBlockedAppsAnalytics,
 }
 

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -3,13 +3,33 @@ import { useAuth } from './useAuth'
 import { defaultPermissions } from '@/api/ebbApi/licenseApi'
 import { usePermissionsStore } from '@/lib/stores/permissionsStore'
 import { useEffect } from 'react'
+import { isDev } from '@/lib/utils/environment.util'
+
+const devPermissions = {
+  canUseHardDifficulty: true,
+  canUseAllowList: true,
+  canUseMultipleProfiles: true,
+  canUseMultipleDevices: true,
+  canUseSmartFocus: true,
+  canUseSlackIntegration: true,
+  canScheduleSessions: true,
+  hasProAccess: true,
+}
 
 export const usePermissions = () => {
   const { user } = useAuth()
   const { data: licenseData } = useLicenseWithDevices(user?.id || null)
   const setPermissions = usePermissionsStore((state) => state.setPermissions)
 
-  const permissions = licenseData?.permissions || defaultPermissions
+  // In dev mode, grant all pro permissions
+  const isDevMode = isDev()
+  console.log('[usePermissions] isDev:', isDevMode, 'import.meta.env.DEV:', import.meta.env.DEV)
+
+  const permissions = isDevMode
+    ? devPermissions
+    : (licenseData?.permissions || defaultPermissions)
+
+  console.log('[usePermissions] permissions:', permissions)
 
   // Sync to store whenever permissions change
   useEffect(() => {

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -23,13 +23,9 @@ export const usePermissions = () => {
 
   // In dev mode, grant all pro permissions
   const isDevMode = isDev()
-  console.log('[usePermissions] isDev:', isDevMode, 'import.meta.env.DEV:', import.meta.env.DEV)
-
   const permissions = isDevMode
     ? devPermissions
     : (licenseData?.permissions || defaultPermissions)
-
-  console.log('[usePermissions] permissions:', permissions)
 
   // Sync to store whenever permissions change
   useEffect(() => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -135,6 +135,9 @@ export type AnalyticsEvent =
   | 'activity_history_delete_all_clicked'
   | 'activity_history_page_changed'
 
+  // Blocking Events
+  | 'apps_and_websites_blocked'
+
 export interface AnalyticsEventProperties {
   // Focus session properties
   difficulty?: 'easy' | 'medium' | 'hard'
@@ -157,6 +160,14 @@ export interface AnalyticsEventProperties {
 
   // Billing properties
   days_remaining?: number
+
+  // Blocking properties
+  blocked_apps_count?: number
+  blocked_websites_count?: number
+  total_blocked_count?: number
+  is_block_list?: boolean
+  blocked_app_names?: string[]
+  blocked_website_names?: string[]
 }
 
 const trackEvent = (

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -136,7 +136,7 @@ export type AnalyticsEvent =
   | 'activity_history_page_changed'
 
   // Blocking Events
-  | 'apps_and_websites_blocked'
+  | 'app_or_website_block_attempt'
 
 export interface AnalyticsEventProperties {
   // Focus session properties
@@ -161,13 +161,8 @@ export interface AnalyticsEventProperties {
   // Billing properties
   days_remaining?: number
 
-  // Blocking properties
-  blocked_apps_count?: number
-  blocked_websites_count?: number
-  total_blocked_count?: number
-  is_block_list?: boolean
-  blocked_app_names?: string[]
-  blocked_website_names?: string[]
+  // Block attempt properties
+  blocked_item_name?: string
 }
 
 const trackEvent = (

--- a/src/pages/FlowPage/FlowPage.tsx
+++ b/src/pages/FlowPage/FlowPage.tsx
@@ -32,7 +32,6 @@ import { EbbWorker } from '@/lib/ebbWorker'
 import { Timer } from './Timer'
 import { MonitorApi } from '@/api/monitorApi/monitorApi'
 import { StorageUtils } from '../../lib/utils/storage.util'
-import { AnalyticsService } from '@/lib/analytics'
 
 type CurrentTrack = {
   song: {
@@ -66,17 +65,6 @@ const startBlocking = async (workflow: Workflow) => {
   // start blocking
   const isBlockList = !workflow.settings.isAllowList
   await invoke('start_blocking', { blockingApps, isBlockList })
-
-  // Track analytics for PostHog
-  if (workflow.id) {
-    const analyticsData = await BlockingPreferenceApi.getWorkflowBlockedAppsAnalytics(workflow.id)
-    AnalyticsService.trackEvent('apps_and_websites_blocked', {
-      ...analyticsData,
-      is_block_list: isBlockList,
-      workflow_id: workflow.id,
-      workflow_name: workflow.name,
-    })
-  }
 }
 
 export const FlowPage = () => {

--- a/src/pages/FlowPage/FlowPage.tsx
+++ b/src/pages/FlowPage/FlowPage.tsx
@@ -32,6 +32,7 @@ import { EbbWorker } from '@/lib/ebbWorker'
 import { Timer } from './Timer'
 import { MonitorApi } from '@/api/monitorApi/monitorApi'
 import { StorageUtils } from '../../lib/utils/storage.util'
+import { AnalyticsService } from '@/lib/analytics'
 
 type CurrentTrack = {
   song: {
@@ -65,6 +66,17 @@ const startBlocking = async (workflow: Workflow) => {
   // start blocking
   const isBlockList = !workflow.settings.isAllowList
   await invoke('start_blocking', { blockingApps, isBlockList })
+
+  // Track analytics for PostHog
+  if (workflow.id) {
+    const analyticsData = await BlockingPreferenceApi.getWorkflowBlockedAppsAnalytics(workflow.id)
+    AnalyticsService.trackEvent('apps_and_websites_blocked', {
+      ...analyticsData,
+      is_block_list: isBlockList,
+      workflow_id: workflow.id,
+      workflow_name: workflow.name,
+    })
+  }
 }
 
 export const FlowPage = () => {


### PR DESCRIPTION
 Track individual app/website block attempts in PostHog
    
       Added PostHog event tracking to monitor when users attempt to access blocked apps/websites during focus sessions.
    
       Changes:
       - Added 'app_or_website_block_attempt' event type in analytics.ts
       - Added 'blocked_item_name' property to track specific blocked items
       - Listen to 'on-app-blocked' event in useNotificationListener.ts
       - Extract trackBlockedApps() helper function for cleaner code
       - Use app_external_id for websites (URLs) and app_name for apps
       - Each block attempt fires a separate PostHog event
       
<img width="872" height="617" alt="image" src="https://github.com/user-attachments/assets/d78f0c62-ed56-4498-8b07-29187aa82aee" />


